### PR TITLE
タグ名を小文字化する処理を削除

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -13,8 +13,7 @@ class PostsController < ApplicationController
   def create
     @post = current_user.posts.build(post_params)
     if @post.save
-      tag_list = tag_params[:tag_names].delete(" ").split(",")
-      @post.save_tags(tag_list)
+      @post.save_tags(tag_params[:tag_names])
       flash[:notice] = "記事を投稿しました"
       redirect_to post_path(@post)
     else

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -37,9 +37,11 @@ class Post < ApplicationRecord
 
   # 受け取ったタグがDBに存在すれば、取得して記事と紐付ける
   # 存在しなければ、作成する
-  def save_tags(tag_list)
+  def save_tags(tags)
+    # 文字列を空白区切りで配列化
+    tag_list = tags.split(/[[:blank:]]+/).select(&:present?)
     tag_list.each do |tag|
-      unless find_tag = Tag.find_by(name: tag.downcase)
+      unless find_tag = Tag.find_by(name: tag)
         begin
           self.tags.create!(name: tag)
         rescue

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,19 +1,11 @@
 class Tag < ApplicationRecord
-  before_save :downcase_tag_name
-
   has_many :post_tag_relations, dependent: :destroy
   has_many :posts, through: :post_tag_relations
 
-  validates :name, presence: true, uniqueness: true, length: { maximum: 50 }
+  validates :name, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 50 }
 
   def self.search(search)
     return Post.page(params[:page]).per(10).order(updated_at: :desc) unless search
     Tag.where('name like ?', "%#{search.delete(" ")}%").map { |tag| tag.posts }
   end
-
-  private
-
-    def downcase_tag_name
-      self.name.downcase!
-    end
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -8,7 +8,7 @@
 
     <div class="f-post-title">
       <%= f.label :tag_names, "タグ" %>
-      <%= f.text_field :tag_names, class: "f-post-title-input", placeholder: "タグ名を Ruby, Rails, Docker のようにカンマ区切りで入力してください", autocomplete: "off" %>
+      <%= f.text_field :tag_names, class: "f-post-title-input", placeholder: "スペース区切りでタグを入力(Rails Docker Ruby)", autocomplete: "off" %>
     </div>
   
     <div class="f-post-body">

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Tag, type: :model do
         expect(tag).to be_valid
       end
     end
+
     context "タグ名が無いとき" do
       it "無効な状態であること" do
         invalid_tag = Tag.new(name: "")
@@ -35,6 +36,7 @@ RSpec.describe Tag, type: :model do
         expect{ tag.save }.to change{ Tag.count }.by(1)
       end
     end
+
     context "既にタグ名が存在するとき" do
       it "無効な状態であること" do
         Tag.create(name: "tagname")
@@ -48,34 +50,37 @@ RSpec.describe Tag, type: :model do
 
         expect(tag.errors[:name]).to include("はすでに存在します")
       end
-    end
 
-    # downcase_tag_name
-    describe "受け取ったタグ名をすべて小文字に変換" do
-      context "タグ名が大文字のとき" do
-        it "すべて小文字で保存されていること" do
-          downcase_tag = Tag.create(name: "TEST_TAG")
+      context "同じ文字列で大文字が既に作成されているとき" do
+        it "無効な状態であること" do
+          Tag.create(name: "TAGNAME")
 
-          expect(downcase_tag.reload.name).to eq "test_tag"
+          expect(tag).to be_invalid
+        end
+
+        it "バリデーションエラーメッセージが表示されること" do
+          Tag.create(name: "TAGNAME")
+          tag.valid?
+
+          expect(tag.errors[:name]).to include("はすでに存在します")
         end
       end
 
-      context "タグ名が小文字のとき" do
-        it "すべて小文字で保存されていること" do
-          downcase_tag = Tag.create(name: "test_tag")
+      context "同じ文字列で小文字で既に作成されているとき" do
+        it "無効な状態であること" do
+          Tag.create(name: "tagname")
 
-          expect(downcase_tag.reload.name).to eq "test_tag"
+          expect(Tag.new(name: "TAGNAME")).to be_invalid
+        end
+
+        it "バリデーションエラーメッセージが表示されること" do
+          Tag.create(name: "tagname")
+          upcase_tag = Tag.new(name: "TAGNAME")
+          upcase_tag.valid?
+
+          expect(upcase_tag.errors[:name]).to include("はすでに存在します")
         end
       end
-
-      context "タグ名が大文字と小文字があるとき" do
-        it "すべて小文字で保存されていること" do
-          downcase_tag = Tag.create(name: "TesT_tAG")
-
-          expect(downcase_tag.reload.name).to eq "test_tag"
-        end
-      end
-
     end
   end
 


### PR DESCRIPTION
バリデーションでタグ名の大文字と小文字の区別をしないように制限したため、タグ名を保存する前に行っていたタグ名の小文字化処理が不要になり削除

処理の変更に伴い単体テストを修正