### PR TITLE
一つの記事に同じタグが重複して登録される処理を修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -32,6 +32,7 @@ class PostsController < ApplicationController
   
   def update
     @post.update(post_params)
+    @post.save_tags(tag_params[:tag_names])
     flash[:notice] = "「#{@post.title}」を更新しました"
     redirect_to post_path
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -48,7 +48,7 @@ class Post < ApplicationRecord
           nil
         end
       else
-        PostTagRelation.create!(post_id: self.id, tag_id: find_tag.id)
+        PostTagRelation.create(post_id: self.id, tag_id: find_tag.id)
       end
     end
   end

--- a/app/models/post_tag_relation.rb
+++ b/app/models/post_tag_relation.rb
@@ -1,4 +1,6 @@
 class PostTagRelation < ApplicationRecord
   belongs_to :post
   belongs_to :tag
+
+  validates_uniqueness_of :post_id, scope: :tag_id
 end

--- a/spec/models/post_tag_relation_spec.rb
+++ b/spec/models/post_tag_relation_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe PostTagRelation, type: :model do
+  let(:user) { FactoryBot.create(:user) }
+  let(:post) { FactoryBot.create(:post, user: user)} 
+
   describe "関連したカラムの削除" do
-    let(:user) { FactoryBot.create(:user) }
-    let(:post) { FactoryBot.create(:post, user: user)} 
     context "記事が削除されたとき" do
       it "中間テーブルのデータも削除されること" do
         post.save_tags( ["rspec"] )
@@ -11,6 +12,31 @@ RSpec.describe PostTagRelation, type: :model do
         expect{ post.destroy }.to change{ PostTagRelation.count }.by(-1)
       end
     end
+  end
 
+  describe "一意制約のチェック" do
+    let!(:tag_create) { post.tags.create(name: "TestTag") }
+    context "一つの記事に別の複数タグが登録されたとき" do
+      it "有効な状態であること" do
+        tag_post = post.tags.create(name: "OtherTag")
+
+        expect(tag_post).to be_valid
+      end
+    end
+
+    context "一つの記事に同じタグが登録されたとき" do
+      it "無効な状態であること" do
+        duplicate_tag_post = post.tags.create(name: "TestTag")
+
+        expect(duplicate_tag_post).to be_invalid
+      end
+
+      it "バリデーションエラーメッセージが表示されること" do
+        duplicate_tag_post = post.tags.create(name: "TestTag")
+        duplicate_tag_post.valid?
+
+        expect(duplicate_tag_post.errors[:name]).to include("はすでに存在します")
+      end
+    end
   end
 end


### PR DESCRIPTION
タグが重複して登録されるのを防止するために一意制約のバリデーションを追記しました。
バリデーションの追加に伴い期待の動作をしているかチェックするために単体テストを追記しました。